### PR TITLE
Add Ability to use Custom Characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ npm i -g oji
 
 Just type `oji` to start interactive emoticon creator! Works on every platform :unicorn:
 
+### :sparkles: Make it your own! :sparkles:
+
+You can add custom characters for each part by creating an optional `~/.oji` directory in your root path. Add new characters to each section by creating a `~/.oji/{file}.txt` with any of the corresponding filenames:
+
+`'arms_symmetric', 'arms_left', 'bodies_symmetric', 'bodies_left', 'cheeks', 'eyes', 'mouths_noses', 'bodies_right', 'arms_right'`
+
 ## :package: npm Dependencies [![Known Vulnerabilities](https://snyk.io/test/github/xxczaki/oji/badge.svg)](https://snyk.io/test/github/xxczaki/oji)
 
 - [inquirer](https://www.npmjs.com/package/inquirer)

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -12,10 +12,20 @@ const getRandomIndex = length => {
 	return Math.floor(Math.random() * length);
 };
 
+const getParts = () => {
+	return ['arms_symmetric', 'arms_left', 'bodies_symmetric', 'bodies_left', 'cheeks', 'eyes', 'mouths_noses', 'bodies_right', 'arms_right'].map(fileName => {
+		let parts = fs.readFileSync(`${__dirname}/parts/${fileName}.txt`, 'utf8').split('\n');
+		const customParts = fs.existsSync(`${homeDir}/.oji/${fileName}.txt`) && fs.readFileSync(`${homeDir}/.oji/${fileName}.txt`, 'utf8').split('\n');
+		if (customParts) {
+			parts = parts.concat(customParts);
+		}
+		return parts;
+	});
+};
+
 // Create emoji!
 module.exports.create = () => {
-	const parts = ['arms_symmetric', 'arms_left', 'bodies_symmetric', 'bodies_left', 'cheeks', 'eyes', 'mouths_noses', 'bodies_right', 'arms_right'].map(fileName =>
-    fs.readFileSync(`${__dirname}/parts/${fileName}.txt`, 'utf8').split('\n'));
+	const parts = getParts();
 	return inquirer.prompt([
 		{
 			type: 'list',
@@ -106,8 +116,7 @@ module.exports.create = () => {
 
 // Create random emoji!
 module.exports.random = () => {
-	const parts = ['arms_symmetric', 'arms_left', 'bodies_symmetric', 'bodies_left', 'cheeks', 'eyes', 'mouths_noses', 'bodies_right', 'arms_right'].map(fileName =>
-		fs.readFileSync(`${__dirname}/parts/${fileName}.txt`, 'utf8').split('\n'));
+	const parts = getParts();
 	// Combine random parts
 	const leftarmIndex = getRandomIndex([...parts[1], ...parts[0]].length);
 	const rightarmIndex = getRandomIndex([...parts[8], ...parts[0]].length);


### PR DESCRIPTION
Hello there! :smile: This is my first attempt at contributing to this library.

### What This Does

This PR adds the ability for users to keep a custom set of characters to use in their emoticons in an `~/.oji` directory.

### Why should this be added?

I came up with the idea for this feature when I noticed that some emoijs I've used elsewhere online have a slightly different character for a little smile than this library (`‿` elsewhere vs `◡` here).

Rather than asking for the smile that I prefer to be added to the library, I thought it might be better not to force a default and instead give users the option to customize their own set of emoticons!

### Alternatives

This setup requires the user to mimic the file structure found in `lib/parts` in `~/.oji` if they want to add their own characters. This may be exposing too much of the internals of the library to the user which may not be desirable. If you feel this is the case, please let me know and perhaps we can discuss a better solution that feels like less of a burden on the users.

I really enjoy this library - it's a really fun tool that I like to use to generate and save many fun emojis! Thanks for your time.